### PR TITLE
Fix inconsistent function protocol types

### DIFF
--- a/lab/bigmap/source/bigmap.c
+++ b/lab/bigmap/source/bigmap.c
@@ -73,8 +73,8 @@ TSprite g_link;
 
 // === PROTOTYPES =====================================================
 
-INLINE void vp_center(VIEWPORT *vp, FIXED x, FIXED y);
-void vp_set_pos(VIEWPORT *vp, FIXED x, FIXED y);
+INLINE void vp_center(VIEWPORT *vp, int x, int y);
+void vp_set_pos(VIEWPORT *vp, int x, int y);
 
 // === MACROS =========================================================
 // === INLINES=========================================================
@@ -218,7 +218,7 @@ void init_main()
 	GRIT_CPY(pal_obj_mem, link_gfxPal);
 	GRIT_CPY(tile_mem[4], link_gfxTiles);
 
-	link_init(&g_link, 120<<8, 80<<8, 0);
+	link_init(&g_link, int2fx(120), int2fx(80), 0);
 
 	//# NOTE: erasing and rendering text flows over into the VDRAW period.
 	//# Using the ASM renderer and placing the text at the bottom limits its effects.
@@ -249,7 +249,7 @@ int main()
 		link_animate(&g_link);
 		link_move(&g_link);
 
-		x= g_link.x>>8, y= g_link.y>>8;
+		x= fx2int(g_link.x), y= fx2int(g_link.y);
 
 		vp_center(&g_vp, x, y);
 		oam_copy(oam_mem, obj_buffer, 128);

--- a/lab/bigmap/source/link.c
+++ b/lab/bigmap/source/link.c
@@ -83,7 +83,7 @@ const OBJ_ATTR cLinkObjs[3]=
 // FUNCTIONS
 // --------------------------------------------------------------------
 
-void link_init(TSprite *link, int x, int y, int obj_id)
+void link_init(TSprite *link, FIXED x, FIXED y, int obj_id)
 {
 	link->x= x;
 	link->y= y;
@@ -159,7 +159,7 @@ void link_animate(TSprite *link)
 
 static void link_ani_stand(TSprite *link)
 {
-	POINT pt= { (link->x>>8)-g_vp.x, (link->y>>8) - g_vp.y };
+	POINT pt= { fx2int(link->x) - g_vp.x, fx2int(link->y) - g_vp.y };
 	OBJ_ATTR *obj= &obj_buffer[link->objId];
 
 	int dir= link->dir;
@@ -197,10 +197,10 @@ static void link_ani_walk(TSprite *link)
 {
 	int dir= link->dir;
 	int sublut= cLookDirs[dir];
-	int frame= (link->aniFrame>>8) & 7;
+	int frame= fx2int(link->aniFrame) & 7;
 	int tid;
 
-	POINT pt= { (link->x>>8)-g_vp.x, (link->y>>8) - g_vp.y };
+	POINT pt= { fx2int(link->x) - g_vp.x, fx2int(link->y) - g_vp.y };
 	OBJ_ATTR *obj= &obj_buffer[link->objId];
 
 

--- a/lab/bigmap/source/link.h
+++ b/lab/bigmap/source/link.h
@@ -41,7 +41,7 @@ typedef struct TSprite
 // PROTOTYPES
 // --------------------------------------------------------------------
 
-void link_init(TSprite *link, int x, int y, int obj_id);
+void link_init(TSprite *link, FIXED x, FIXED y, int obj_id);
 void link_set_state(TSprite *link, u32 state);
 void link_input(TSprite *link);
 


### PR DESCRIPTION
Fixes function prototypes in bigmap.c being inconsistent to implementations, causing issues when types change. This change makes it compatible with Tonc v1.4.5.